### PR TITLE
Adding include_extras: false where needed

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -145,6 +145,7 @@
   version: '0.1'
   setup_options: '--offline'
   numpy_compiled_extensions: false
+  include_extras: false
 
 # python-cpl has a recipe template for now
 - name: python-cpl
@@ -181,6 +182,7 @@
 - name: regions
   version: '0.1'
   setup_options: '--offline'
+  include_extras: false
 
 
 ################################################################


### PR DESCRIPTION
As far as I see only a few packages use `extras_require` in their setup.py. 
- astroplan
- gammapy
- glue
- regions
- sunpy

So this PR adds `include_extras: false` to the ones that we build here.
