### PR TITLE
Adding glueviz version 0.8.2

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -184,6 +184,9 @@
   setup_options: '--offline'
   include_extras: false
 
+- name: glueviz
+  version: '0.8.2'
+
 
 ################################################################
 # These are additional dependencies of some of the affiliated  #


### PR DESCRIPTION
This should be copied over from `conda-forge`, but since glue is an astropy affiliated, too I think it makes sense to host in the `astropy` for the sake of completeness.

What do you think @astrofrog? 
