### PR TITLE
Changing minimum required verson for conda-build 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ install:
     - conda config --add channels astropy
     - conda config --add channels conda-forge
 
-    - conda install conda-build>=1.21.7
+    - conda install conda-build>=1.21.11
 
     # Install conda-build-all
     - conda install -c conda-forge conda-build-all

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,7 +55,7 @@ install:
     - cmd: conda update --quiet conda
     - cmd: conda config --add channels astropy
     - cmd: conda config --add channels conda-forge
-    - cmd: conda install conda-build>=1.21.7
+    - cmd: conda install conda-build>=1.21.11
     - cmd: conda install --quiet astropy anaconda-client jinja2 cython
     # These installs are needed on windows but not other platforms.
     - cmd: conda install patch psutil


### PR DESCRIPTION
... due to https://github.com/conda/conda-build/pull/1181

I think we should be fine without this change, but better to be on the safe side.
