### PR TITLE
Adding pytest-mpl version 0.5

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -214,3 +214,6 @@
 
 - name: corner
   version: 2.0.1
+
+- name: pytest-mpl
+  version: 0.5


### PR DESCRIPTION
Adding `pytest-mpl` as it's a dependency for a few affiliated packages.  It's still installed via pip, and I would rather have a copy in the astropy channel, too than to add conda-forge as a channel to those travis builds.

@mwcraig  @astrofrog - Feel free to close this without merge if you don't like the approach.
