### PR TITLE
Update ginga and switch to conda build v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,10 +41,10 @@ install:
     - conda config --add channels astropy
     - conda config --add channels conda-forge
 
-    - conda install conda-build=1.21.14
+    - conda install conda-build=12.0*
 
     # Install conda-build-all
-    - conda install -c conda-forge conda-build-all=0.13*
+    - conda install -c conda-forge conda-build-all=1.0*
 
     # Finally, install extruder
     - conda install -c astropy extruder

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ install:
     - conda config --add channels astropy
     - conda config --add channels conda-forge
 
-    - conda install conda-build=12.0*
+    - conda install conda-build=2.0*
 
     # Install conda-build-all
     - conda install -c conda-forge conda-build-all=1.0*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,11 +55,11 @@ install:
     - cmd: conda update --quiet conda
     - cmd: conda config --add channels astropy
     - cmd: conda config --add channels conda-forge
-    - cmd: conda install conda-build=1.21.14
+    - cmd: conda install conda-build=2.0*
     - cmd: conda install --quiet astropy anaconda-client jinja2 cython
     # These installs are needed on windows but not other platforms.
     - cmd: conda install patch psutil
-    - cmd: conda install -c conda-forge conda-build-all=0.13*
+    - cmd: conda install -c conda-forge conda-build-all=1.0*
 
     # Finally, install extruder
     - cmd: conda install extruder

--- a/requirements.yml
+++ b/requirements.yml
@@ -124,7 +124,7 @@
   python: '>=2.6|>=3.3'
 
 - name: ginga
-  version: 2.5.20160802122200
+  version: 2.5.20160901093400
   numpy_compiled_extensions: false
   python: '>2.6'
   setup_options: '--offline'


### PR DESCRIPTION
This is really two changes at once, or perhaps a substantive change (conda build 2) and a convenient test case (building the latest ginga).
