### PR TITLE
Building APLpy for py 3.5.2

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -87,7 +87,7 @@
 - name: APLpy
   version: '1.1.1'
   setup_options: '--offline'
-  python: '>2.6,<3.5.2'
+  python: '>2.6'
 
 - name: specutils
   version: '0.2.2'


### PR DESCRIPTION
The configparser issue has been fixed for APLpy 1.1.1, so removing the python version restriction.

[edit:] this was a red herring, but nevertheless good to fix it. ~~Hopefully this will solve the issue reported in https://github.com/astropy/astroquery/pull/617#issuecomment-258718031~~