### PR TITLE
Pinning conda-build version to 2.0.10 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ install:
     # downgrading conda itself from conda-forge.
     - conda config --add channels defaults
 
-    - conda install conda-build=2.0*
+    - conda install conda-build=2.0.10
 
     # Install conda-build-all
     - conda install conda-build-all=1.0*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,7 +55,7 @@ install:
     - cmd: conda update --quiet conda
     - cmd: conda config --add channels astropy
     - cmd: conda config --add channels conda-forge
-    - cmd: conda install conda-build=2.0*
+    - cmd: conda install conda-build=2.0.10
     - cmd: conda install --quiet astropy anaconda-client jinja2 cython
     # These installs are needed on windows but not other platforms.
     - cmd: conda install patch psutil


### PR DESCRIPTION
as it was the latest knowingly working one. 

As the problem triggering #105 was not shown during the PR testing, I expect this to pass even if it doesn't fix the issue on master.