### PR TITLE
Don't build python 3.6 packages just yet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
         # The python build restriction MUST be set at the moment, though it
         # can have any value. The setting below avoids known-bad builds on
         # python 2.6 and 3.3 for some packages.
-        - PYTHON_BUILD_RESTRICTIONS="2.7*|>=3.4"
+        - PYTHON_BUILD_RESTRICTIONS="2.7*|>=3.4,<3.6"
 
         # The value below needs to be set but will be ignored.
         - CONDA_NPY="1.11"


### PR DESCRIPTION
#114 should be fixed before we can build python 3.6 as some of the packages may not be compatible yet, so temporarily disabling python 3.6 with this PR.