### PR TITLE
Building first batch of packages for python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
         # The python build restriction MUST be set at the moment, though it
         # can have any value. The setting below avoids known-bad builds on
         # python 2.6 and 3.3 for some packages.
-        - PYTHON_BUILD_RESTRICTIONS="2.7*|>=3.4,<3.6"
+        - PYTHON_BUILD_RESTRICTIONS="2.7*|>=3.4"
 
         # The value below needs to be set but will be ignored.
         - CONDA_NPY="1.11"

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,4 +66,4 @@ script:
     # Get ready to build.
     - extrude_recipes requirements.yml
     # Packages are uploaded as they are built.
-    - if [[ -d recipes ]]; then conda build-all recipes --matrix-conditions="python $PYTHON_BUILD_RESTRICTIONS" --inspect-channels conda-forge astropy $UPLOAD; fi
+    - if [[ -d recipes ]]; then conda build-all recipes --matrix-conditions="python $PYTHON_BUILD_RESTRICTIONS"  --matrix-max-n-minor-versions 3 --inspect-channels conda-forge astropy $UPLOAD; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -75,4 +75,4 @@ test_script:
     # Get ready to build.
     - "%CMD_IN_ENV% extrude_recipes requirements.yml"
     # Packages are uploaded as they are built.
-    - if exist recipes %CMD_IN_ENV% conda build-all recipes --matrix-conditions="python %PYTHON_BUILD_RESTRICTIONS%"  --inspect-channels conda-forge astropy %UPLOAD%
+    - if exist recipes %CMD_IN_ENV% conda build-all recipes --matrix-conditions="python %PYTHON_BUILD_RESTRICTIONS%"  --matrix-max-n-minor-versions 3 --inspect-channels conda-forge astropy %UPLOAD%

--- a/recipe_templates/asdf/meta.yaml
+++ b/recipe_templates/asdf/meta.yaml
@@ -37,7 +37,7 @@ requirements:
     - pyyaml >=3.10
     - jsonschema >=2.3.0
     - six >=1.9.0
-    - numpy
+    - numpy >1.9
     - pytest >=2.7.2
 
   run:
@@ -46,7 +46,7 @@ requirements:
     - jsonschema >=2.3.0
     - six >=1.9.0
     - pytest >=2.7.2
-    - numpy
+    - numpy >1.9
 
 test:
   # Python imports

--- a/requirements.yml
+++ b/requirements.yml
@@ -34,6 +34,7 @@
   version: 1.4.0
   setup_options: '--offline'
   numpy_compiled_extensions: false
+  python: '<3.6*'
 
 - name: pydl
   version: 0.5.3
@@ -45,17 +46,20 @@
   version: 0.9.8
   setup_options: '--offline'
   numpy_compiled_extensions: false
+  python: '<3.6*'
 
 # ccdproc has a recipe template
 - name: ccdproc
   version: 1.2.0
   setup_options: '--offline'
   numpy_compiled_extensions: false
+  python: '<3.6*'
 
 - name: wcsaxes
   version: '0.9'
   setup_options: '--offline'
   numpy_compiled_extensions: false
+  python: '<3.6*'
 
 - name: gammapy
   version: '0.4'
@@ -63,6 +67,7 @@
   numpy_compiled_extensions: false
   python: '<3.5.2'
   include_extras: false
+  python: '<3.6*'
 
 # Fails because its astropy helpers is ancient/tries to import astropy???
 # - name: pyvo
@@ -82,6 +87,7 @@
   python: '<3.5.2'
   excluded_platforms:
       - 'win-64'
+  python: '<3.6*'
 
 # APLpy currently has a recipe template
 - name: APLpy
@@ -93,6 +99,7 @@
   version: '0.2.2'
   setup_options: '--offline'
   numpy_compiled_extensions: false
+  python: '<3.6*'
 
 # imexam has a recipe template
 - name: imexam
@@ -134,12 +141,14 @@
   version: '0.8'
   setup_options: '--offline'
   numpy_compiled_extensions: false
+  python: '<3.6*'
 
 # reproject has a recipe template
 - name: reproject
   version: '0.3.1'
   setup_options: '--offline'
   numpy_compiled_extensions: true
+  python: '<3.6*'
 
 - name: astroplan
   version: '0.2'
@@ -160,6 +169,7 @@
 - name: omnifit
   version: '0.2.1'
   setup_options: '--offline'
+  python: '<3.6*'
 
 # maltpynt does not seem to actually update astropy_helpers during setup.
 - name: maltpynt
@@ -167,10 +177,12 @@
   setup_options: '--offline'
   numpy_compiled_extensions: false
   python: '<3.5.2'
+  python: '<3.6*'
 
 - name: spectral-cube
   version: '0.4.0'
   setup_options: '--offline'
+  python: '<3.6*'
 
 - name: halotools
   version: '0.4'
@@ -207,12 +219,15 @@
 
 - name: pyephem
   version: 3.7.6.0
+  python: '<3.6*'
 
 - name: hgtools
   version: '6.3'
+  python: '<3.6*'
 
 - name: keyring
   version: '9.0'
+  python: '<3.6*'
 
 # lmfit is required for omnifit
 # Testing whether this was the problem for #73
@@ -221,6 +236,7 @@
 
 - name: iminuit
   version: 1.2
+  python: '<3.6*'
 
 - name: emcee
   version: 2.2.1
@@ -232,9 +248,12 @@
 
 - name: pytest-mpl
   version: 0.7
+  python: '<3.6*'
 
 - name: pytest-arraydiff
   version: 0.1
+  python: '<3.6*'
 
 - name: extinction
   version: 0.3.0
+  python: '<3.6*'

--- a/requirements.yml
+++ b/requirements.yml
@@ -227,6 +227,7 @@
 
 - name: corner
   version: 2.0.1
+  python: '<3.6*'
 
 - name: pytest-mpl
   version: 0.7

--- a/requirements.yml
+++ b/requirements.yml
@@ -224,6 +224,7 @@
 
 - name: emcee
   version: 2.2.1
+  python: '<3.6*'
 
 - name: corner
   version: 2.0.1

--- a/requirements.yml
+++ b/requirements.yml
@@ -186,6 +186,7 @@
 
 - name: glueviz
   version: '0.9.1'
+  python: '<3.6*'
 
 # cluster-lensing has a recipe template
 - name: cluster-lensing

--- a/requirements.yml
+++ b/requirements.yml
@@ -87,7 +87,7 @@
 - name: APLpy
   version: '1.1.1'
   setup_options: '--offline'
-  python: '>2.6'
+  python: '<3.6*'
 
 - name: specutils
   version: '0.2.2'


### PR DESCRIPTION
This PR will add Python 3.6 builds for packages that seem to be compatible with it. 

This partly address issue #119