### PR TITLE
Adding python3.6 for appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,6 +26,9 @@ environment:
     # the appveyor setup only sets up the SDK once, so separate by python
     # versions.
     - TARGET_ARCH: "x64"
+      PYTHON_BUILD_RESTRICTIONS: "3.6*"
+      CONDA_PY: "36"
+    - TARGET_ARCH: "x64"
       PYTHON_BUILD_RESTRICTIONS: "2.7*"
       CONDA_PY: "27"
     - TARGET_ARCH: "x64"
@@ -34,9 +37,6 @@ environment:
     - TARGET_ARCH: "x64"
       PYTHON_BUILD_RESTRICTIONS: "3.5*"
       CONDA_PY: "35"
-    - TARGET_ARCH: "x64"
-      PYTHON_BUILD_RESTRICTIONS: "3.6*"
-      CONDA_PY: "36"
     # For 32 bit builds there are no compiler issues, let Obvious-CI
     # handle the matrix.
     # - TARGET_ARCH: "x86"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,6 +34,9 @@ environment:
     - TARGET_ARCH: "x64"
       PYTHON_BUILD_RESTRICTIONS: "3.5*"
       CONDA_PY: "35"
+    - TARGET_ARCH: "x64"
+      PYTHON_BUILD_RESTRICTIONS: "3.6*"
+      CONDA_PY: "36"
     # For 32 bit builds there are no compiler issues, let Obvious-CI
     # handle the matrix.
     # - TARGET_ARCH: "x86"


### PR DESCRIPTION
Currently trying to build only those 16 packages that passed on the linux travis.

Cancelling travis right away as this PR only affects the windows builds.