### PR TITLE
Building more packages for python 3.6

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -34,7 +34,6 @@
   version: 1.4.0
   setup_options: '--offline'
   numpy_compiled_extensions: false
-  python: '<3.6*'
 
 - name: pydl
   version: 0.5.3
@@ -65,7 +64,6 @@
   numpy_compiled_extensions: false
   python: '<3.5.2'
   include_extras: false
-  python: '<3.6*'
 
 # Fails because its astropy helpers is ancient/tries to import astropy???
 # - name: pyvo
@@ -215,7 +213,6 @@
 
 - name: hgtools
   version: '6.3'
-  python: '<3.6*'
 
 # lmfit is required for omnifit
 # Testing whether this was the problem for #73
@@ -224,7 +221,6 @@
 
 - name: iminuit
   version: 1.2
-  python: '<3.6*'
 
 - name: emcee
   version: 2.2.1
@@ -240,8 +236,6 @@
 
 - name: pytest-arraydiff
   version: 0.1
-  python: '<3.6*'
 
 - name: extinction
   version: 0.3.0
-  python: '<3.6*'

--- a/requirements.yml
+++ b/requirements.yml
@@ -217,10 +217,6 @@
   version: '6.3'
   python: '<3.6*'
 
-- name: keyring
-  version: '9.0'
-  python: '<3.6*'
-
 # lmfit is required for omnifit
 # Testing whether this was the problem for #73
 #- name: lmfit


### PR DESCRIPTION
This is the last batch of packages that build out of the box with python 3.6. The remaining ones have various issues:

* mpl/qt issue: https://github.com/conda-forge/matplotlib-feedstock/issues/36 for ``pytest-mpl``, ``corner``, ``imexam``, ``aplpy

* latest release incompatibility with Configparser: ``montage-wrapper``, ``maltpynt``, ``gammapy`` (a newer version is available in #99)

* missing older (1.9, 1.10) numpy builds: ``reproject``, ``emcee``

* other reason: ``glueviz``, ``pyephem``

There are 4 other packages that conda.resolve deems unbuildable probably due to missing dependencies: ``naima`` (emcee?), ``omnifit`` (lmfit?), ``spherical-geometry``, ``ccdproc``

For follow-ups see #119