### PR TITLE
Pin conda version to v4.2*

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,14 @@ env:
         # can have any value. The setting below avoids known-bad builds on
         # python 2.6 and 3.3 for some packages.
         - PYTHON_BUILD_RESTRICTIONS="2.7*|>=3.4"
+        # If you want to restrict the numpy version beyond what is in the
+        # individual package requirements, do that here. Can be helpful after
+        # a new numpy release while continuum and conda-forge are still building
+        # out support for the release.
+
+        # If you do not want a numpy build restriction, set
+        # NUMPY_BUILD_RESTRICTION=""
+        - NUMPY_BUILD_RESTRICTION="numpy <1.12"
 
         # The value below needs to be set but will be ignored.
         - CONDA_NPY="1.11"
@@ -73,7 +81,4 @@ script:
     - extrude_recipes requirements.yml
     # Packages are uploaded as they are built.
 
-    # We do not want to pick up numpy 1.12 just yet, temporarily disabling
-    # conda-forge
-    - conda config --remove channels conda-forge
-    - if [[ -d recipes ]]; then conda build-all recipes --matrix-conditions="python $PYTHON_BUILD_RESTRICTIONS"  --matrix-max-n-minor-versions 3 --inspect-channels astropy $UPLOAD; fi
+    - if [[ -d recipes ]]; then conda build-all recipes --matrix-conditions "python $PYTHON_BUILD_RESTRICTIONS" "$NUMPY_BUILD_RESTRICTION"  --matrix-max-n-minor-versions 3 --inspect-channels conda-forge astropy $UPLOAD; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,4 +72,8 @@ script:
     # Get ready to build.
     - extrude_recipes requirements.yml
     # Packages are uploaded as they are built.
-    - if [[ -d recipes ]]; then conda build-all recipes --matrix-conditions="python $PYTHON_BUILD_RESTRICTIONS"  --matrix-max-n-minor-versions 3 --inspect-channels conda-forge astropy $UPLOAD; fi
+
+    # We do not want to pick up numpy 1.12 just yet, temporarily disabling
+    # conda-forge
+    - conda config --remove channels conda-forge
+    - if [[ -d recipes ]]; then conda build-all recipes --matrix-conditions="python $PYTHON_BUILD_RESTRICTIONS"  --matrix-max-n-minor-versions 3 --inspect-channels astropy $UPLOAD; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ env:
 
         # The value below needs to be set but will be ignored.
         - CONDA_NPY="1.11"
+        - CONDA_VERSION=4.2*
 
 # Matrix is fully specified (for now) by os versions
 
@@ -32,6 +33,9 @@ install:
     - bash miniconda.sh -b -p $CONDA_INSTALL_LOCN
     - export PATH=${CONDA_INSTALL_LOCN}/bin:$PATH
     - conda config --set always_yes true
+
+    - PIN_FILE_CONDA=${CONDA_INSTALL_LOCN}/conda-meta/pinned
+    - echo "conda ${CONDA_VERSION}" > $PIN_FILE_CONDA
 
     - conda update --quiet conda
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,7 @@ environment:
 
   # The value below will be ignored but needs to be set for conda-build-all
   CONDA_NPY: "1.11"
+  CONDA_VERSION: "4.2.*"
 
   matrix:
     # Unfortunately, compiler/SDK configuration for 64 bit builds depends on
@@ -55,7 +56,7 @@ install:
     - cmd: SET PATH=%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\Scripts;%PATH%
 
     - cmd: conda config --set always_yes true
-    - cmd: conda update --quiet conda
+    - cmd: conda install --quiet conda=%CONDA_VERSION%
     - cmd: conda config --add channels astropy
     - cmd: conda config --add channels conda-forge
     - cmd: conda install conda-build=2.0.10

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,14 @@ environment:
   # Python version restrictions that should apply to all builds regardless
   # of any package-specific version restrictions
   PYTHON_BUILD_RESTRICTIONS: "2.7*|>=3.4"
+  # If you want to restrict the numpy version beyond what is in the
+  # individual package requirements, do that here. Can be helpful after
+  # a new numpy release while continuum and conda-forge are still building
+  # out support for the release.
 
+  # If you do not want a numpy build restriction, set
+  # NUMPY_BUILD_RESTRICTION=""
+  NUMPY_BUILD_RESTRICTION: "numpy <1.12"
   BINSTAR_TOKEN:
     # Paste the security token for your destination conda channel here.
     secure: In551w7v371boSMxAcNcHccXMbcLyVImifhayYopb02ZqkUGYV8QyDu1tjVbKaJz
@@ -82,4 +89,4 @@ test_script:
     # Get ready to build.
     - "%CMD_IN_ENV% extrude_recipes requirements.yml"
     # Packages are uploaded as they are built.
-    - if exist recipes %CMD_IN_ENV% conda build-all recipes --matrix-conditions="python %PYTHON_BUILD_RESTRICTIONS%"  --matrix-max-n-minor-versions 3 --inspect-channels conda-forge astropy %UPLOAD%
+    - if exist recipes %CMD_IN_ENV% conda build-all recipes --matrix-conditions "python %PYTHON_BUILD_RESTRICTIONS%" "%NUMPY_BUILD_RESTRICTION%"  --matrix-max-n-minor-versions 3 --inspect-channels conda-forge astropy %UPLOAD%

--- a/requirements.yml
+++ b/requirements.yml
@@ -239,5 +239,9 @@
 - name: pytest-arraydiff
   version: 0.1
 
+# There are some numpy 1.10 & python 3.6 issues on osx that fails the build of
+# extinction, temporarily exclude that platform
 - name: extinction
   version: 0.3.0
+  excluded_platforms:
+      - 'osx-64'

--- a/requirements.yml
+++ b/requirements.yml
@@ -163,6 +163,7 @@
 - name: omnifit
   version: '0.2.1'
   setup_options: '--offline'
+  python: '<3.5.2'
 
 # maltpynt does not seem to actually update astropy_helpers during setup.
 - name: maltpynt


### PR DESCRIPTION
Apparently it's a simple and known issue, ``conda-build`` is not yet support conda >=4.3, so pinning conda to 4.2 should solve all these building issues as of https://github.com/SciTools/conda-build-all/issues/76

This affect all of the PRs, so better to handle separately and the rebase those PRs.