### PR TITLE
Building packages with numpy 1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,10 @@ env:
         # out support for the release.
 
         # If you do not want a numpy build restriction, set
-        # NUMPY_BUILD_RESTRICTION=""
-        - NUMPY_BUILD_RESTRICTION="numpy <1.12"
+        - NUMPY_BUILD_RESTRICTION=
 
         # The value below needs to be set but will be ignored.
-        - CONDA_NPY="1.11"
+        - CONDA_NPY="1.12"
         - CONDA_VERSION=4.2*
         # the python version restriction above overrides this broader setting.
         - MAX_N_MINOR_VERSIONS="4"
@@ -84,4 +83,4 @@ script:
     - extrude_recipes requirements.yml
     # Packages are uploaded as they are built.
 
-    - if [[ -d recipes ]]; then conda build-all recipes --matrix-conditions "python $PYTHON_BUILD_RESTRICTIONS" "$NUMPY_BUILD_RESTRICTION"  --matrix-max-n-minor-versions 3 --inspect-channels conda-forge astropy $UPLOAD; fi
+    - if [[ -d recipes ]]; then conda build-all recipes --matrix-conditions "python $PYTHON_BUILD_RESTRICTIONS" $NUMPY_BUILD_RESTRICTION  --matrix-max-n-minor-versions 3 --inspect-channels conda-forge astropy $UPLOAD; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,14 +18,14 @@ environment:
   # out support for the release.
 
   # If you do not want a numpy build restriction, set
-  # NUMPY_BUILD_RESTRICTION=""
-  NUMPY_BUILD_RESTRICTION: "numpy <1.12"
+  NUMPY_BUILD_RESTRICTION=""
+
   BINSTAR_TOKEN:
     # Paste the security token for your destination conda channel here.
     secure: In551w7v371boSMxAcNcHccXMbcLyVImifhayYopb02ZqkUGYV8QyDu1tjVbKaJz
 
   # The value below will be ignored but needs to be set for conda-build-all
-  CONDA_NPY: "1.11"
+  CONDA_NPY: "1.12"
   CONDA_VERSION: "4.2.*"
 
   matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ environment:
   # out support for the release.
 
   # If you do not want a numpy build restriction, set
-  NUMPY_BUILD_RESTRICTION=""
+  NUMPY_BUILD_RESTRICTION: ""
 
   BINSTAR_TOKEN:
     # Paste the security token for your destination conda channel here.
@@ -90,4 +90,4 @@ test_script:
     # Get ready to build.
     - "%CMD_IN_ENV% extrude_recipes requirements.yml"
     # Packages are uploaded as they are built.
-    - if exist recipes %CMD_IN_ENV% conda build-all recipes --matrix-conditions "python %PYTHON_BUILD_RESTRICTIONS%" "%NUMPY_BUILD_RESTRICTION%"  --matrix-max-n-minor-versions 3 --inspect-channels conda-forge astropy %UPLOAD%
+    - if exist recipes %CMD_IN_ENV% conda build-all recipes --matrix-conditions "python %PYTHON_BUILD_RESTRICTIONS%" %NUMPY_BUILD_RESTRICTION%  --matrix-max-n-minor-versions 3 --inspect-channels conda-forge astropy %UPLOAD%

--- a/requirements.yml
+++ b/requirements.yml
@@ -140,7 +140,7 @@
   version: '0.3.1'
   setup_options: '--offline'
   numpy_compiled_extensions: true
-  python: '<3.6*'
+  python: '2.7*|>=3.5*'
 
 - name: astroplan
   version: '0.2'

--- a/requirements.yml
+++ b/requirements.yml
@@ -186,9 +186,9 @@
   setup_options: '--offline'
   include_extras: false
 
-- name: glueviz
-  version: '0.9.1'
-  python: '<3.6*'
+#- name: glueviz
+#  version: '0.9.1'
+#  python: '<3.6*'
 
 # cluster-lensing has a recipe template
 - name: cluster-lensing

--- a/requirements.yml
+++ b/requirements.yml
@@ -53,6 +53,7 @@
   version: 1.2.0
   setup_options: '--offline'
   numpy_compiled_extensions: false
+  python: '<3.6*'
 
 - name: wcsaxes
   version: '0.9'

--- a/requirements.yml
+++ b/requirements.yml
@@ -142,6 +142,8 @@
   setup_options: '--offline'
   numpy_compiled_extensions: true
   python: '2.7*|>=3.5*'
+  excluded_platforms:
+      - 'osx-64'
 
 - name: astroplan
   version: '0.2'

--- a/requirements.yml
+++ b/requirements.yml
@@ -144,6 +144,7 @@
   python: '2.7*|>=3.5*'
   excluded_platforms:
       - 'osx-64'
+      - 'win-64'
 
 - name: astroplan
   version: '0.2'


### PR DESCRIPTION
Workarounds that needs to be lifted at some point:
 * glueviz was commented out, as we don't have a working recipe template here, and conda-forge doesn't have the updated versions yet (with numpy 1.12, python 3.6)
 * we don't yet build reproject for windows/osx as there are missing versions of dependencies in those platforms
 * ccdproc doesn't yet build for python3.6