### PR TITLE
Remove conda-build pinning and update minimum conda-build-all version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ install:
     - conda install conda-build
 
     # Install conda-build-all
-    - conda install conda-build-all>=1.0.2
+    - conda install conda-build-all
 
     # Finally, install extruder
     - conda install -c astropy extruder

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,10 +59,10 @@ install:
     # downgrading conda itself from conda-forge.
     - conda config --add channels defaults
 
-    - conda install conda-build=2.0.10
+    - conda install conda-build
 
     # Install conda-build-all
-    - conda install conda-build-all=1.0*
+    - conda install conda-build-all>=1.0.2
 
     # Finally, install extruder
     - conda install -c astropy extruder

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,7 +71,7 @@ install:
     - cmd: conda install --quiet astropy anaconda-client jinja2 cython
     # These installs are needed on windows but not other platforms.
     - cmd: conda install patch psutil
-    - cmd: conda install -c conda-forge conda-build-all=1.0*
+    - cmd: conda install -c conda-forge conda-build-all>=1.0.2
 
     # Finally, install extruder
     - cmd: conda install extruder

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,7 +71,7 @@ install:
     - cmd: conda install --quiet astropy anaconda-client jinja2 cython
     # These installs are needed on windows but not other platforms.
     - cmd: conda install patch psutil
-    - cmd: conda install -c conda-forge conda-build-all>=1.0.2
+    - cmd: conda install -c conda-forge conda-build-all
 
     # Finally, install extruder
     - cmd: conda install extruder


### PR DESCRIPTION
This will, hopefully, close #134, which was fixed in `conda-build-all` v1.0.2. Not sure why that version is not being installed, but this should force it.