### PR TITLE
Enable emcee and corner builds for py36

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -219,13 +219,11 @@
 - name: iminuit
   version: 1.2
 
-#- name: emcee
-#  version: 2.2.1
-#  python: '<3.6*'
+- name: emcee
+  version: 2.2.1
 
 - name: corner
   version: 2.0.1
-  python: '<3.6*'
 
 - name: pytest-mpl
   version: 0.7


### PR DESCRIPTION
The conda recipes in conda-forge for both `emcee` and `corner` have been updated to support Python 3.6. This PR reenables them so that `naima` can be installed from the `astropy` conda channel without requiring `conda-forge`.