### PR TITLE
Pin conda-build to version 2.x in preparation for release of 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ install:
     # downgrading conda itself from conda-forge.
     - conda config --add channels defaults
 
-    - conda install conda-build
+    - conda install conda-build=2
 
     # Install conda-build-all
     - conda install -c conda-forge conda-build-all=1.0.2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,7 +64,7 @@ install:
     - cmd: conda config --add channels astropy
     - cmd: conda config --add channels astropy-ci-extras
     - cmd: conda config --add channels conda-forge
-    - cmd: conda install conda-build=2.0.10
+    - cmd: conda install conda-build=2
     - cmd: conda install --quiet astropy anaconda-client jinja2 cython
     # These installs are needed on windows but not other platforms.
     - cmd: conda install patch psutil


### PR DESCRIPTION
I don't know of any issues with conda build 3, this is simply a defensive move.