### PR TITLE
Update CI to use channel copying

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
         - DESTINATION_CONDA_CHANNEL="astropy"
         - TARGET_ARCH="x64"
         - CONDA_INSTALL_LOCN="${HOME}/miniconda"
+        - PACKAGES_TO_COPY="copy_me.yaml"
 
         # Defines BINSTAR_TOKEN for your binstar channel
         - secure: "1Y5eKpseYF3aOZ97RfAZ/hykoK0xxG03Bv0Zxvnez3VPpF8AJM7vCWvuvSXYOqlSH2AqHtuLEMSsjkdIXrcyZ1FLGCXcTtY+2kT3QUxLXTvCCCStX4oodOGIgA/A973rjBcQNCFyHauvgivDE5ENUYUDU8bqBZbx0vOlCJC74dyFkTSklNpHTpM3pUh9rIjbhw603UBtVySLmk4X9sS/yf03Al9FEeT3q+jGQKYwT+VhXKakywlzWeoE/Y8PlrVkxdgzq3ktfXme+W8LzFTzY4gzgdHSTPj/A7SHHRkODnJxiW2iYKbDVp3ouBlYN+tq+Km1IA9Qo6wYdoYrHVh6w2F3L+2dr5qabtW6X4T0bulxA7pr2KgtDPpgfvmleIifaGlLe8hKUodQKZeQMiqy4zLUnk4KOmzq5HcRO+Mjn8c2uiPjU9P7aUy9gWrJHxd0uTrecrNHrqCpz3yepf+fpfIjo16iqB0Ck1JsjIg/cekQBRVFagZfSdIhg7f5B7Dq44sbYAmxLjaNgh6ArTmGkImPjJtqY5bllMHzp0r6IdnKswBYmafO2lZjqHWBP6mtvtJC1tWBBFezWPG/jRbqHM98J3UtGVVKKsHiseX97Z4il9mb0SvLDtwEf0ZyMZnSxhHt5wbPV5X+LxTSSjjztb38/BAN3ZwxaRxftKyeuIY="
@@ -81,6 +82,16 @@ script:
       fi
     # Get ready to build.
     - extrude_recipes requirements.yml
+    # If there are packages to copy, do that first, but only if UPLOAD is set,
+    # and only on Linux, since those travis machines are fastest. Copy only
+    # needs to happen once to copy all available builds.
+    - if [ -e $PACKAGES_TO_COPY ] && [ $TRAVIS_OS_NAME == "linux" ]; then
+        echo "Will potentially copy these packages when merged:";
+        cat $PACKAGES_TO_COPY;
+        if [ ! -z $UPLOAD ]; then
+          copy_packages $PACKAGES_TO_COPY $DESTINATION_CONDA_CHANNEL;
+        fi
+      fi
     # Packages are uploaded as they are built.
 
     - if [[ -d recipes ]]; then conda build-all recipes --matrix-conditions "python $PYTHON_BUILD_RESTRICTIONS" $NUMPY_BUILD_RESTRICTION  --matrix-max-n-minor-versions $MAX_N_MINOR_VERSIONS --inspect-channels conda-forge astropy $UPLOAD; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
         - DESTINATION_CONDA_CHANNEL="astropy"
         - TARGET_ARCH="x64"
         - CONDA_INSTALL_LOCN="${HOME}/miniconda"
-        - PACKAGES_TO_COPY="copy_me.yaml"
+        - PACKAGES_TO_COPY="copy_from.yaml"
 
         # Defines BINSTAR_TOKEN for your binstar channel
         - secure: "1Y5eKpseYF3aOZ97RfAZ/hykoK0xxG03Bv0Zxvnez3VPpF8AJM7vCWvuvSXYOqlSH2AqHtuLEMSsjkdIXrcyZ1FLGCXcTtY+2kT3QUxLXTvCCCStX4oodOGIgA/A973rjBcQNCFyHauvgivDE5ENUYUDU8bqBZbx0vOlCJC74dyFkTSklNpHTpM3pUh9rIjbhw603UBtVySLmk4X9sS/yf03Al9FEeT3q+jGQKYwT+VhXKakywlzWeoE/Y8PlrVkxdgzq3ktfXme+W8LzFTzY4gzgdHSTPj/A7SHHRkODnJxiW2iYKbDVp3ouBlYN+tq+Km1IA9Qo6wYdoYrHVh6w2F3L+2dr5qabtW6X4T0bulxA7pr2KgtDPpgfvmleIifaGlLe8hKUodQKZeQMiqy4zLUnk4KOmzq5HcRO+Mjn8c2uiPjU9P7aUy9gWrJHxd0uTrecrNHrqCpz3yepf+fpfIjo16iqB0Ck1JsjIg/cekQBRVFagZfSdIhg7f5B7Dq44sbYAmxLjaNgh6ArTmGkImPjJtqY5bllMHzp0r6IdnKswBYmafO2lZjqHWBP6mtvtJC1tWBBFezWPG/jRbqHM98J3UtGVVKKsHiseX97Z4il9mb0SvLDtwEf0ZyMZnSxhHt5wbPV5X+LxTSSjjztb38/BAN3ZwxaRxftKyeuIY="

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
   # File with list of packages to potentially copy from conda-forge.
   # At the moment, copying is NOT done here because doing it on
   # one platform copies everything.
-  PACKAGES_TO_COPY: "copy_me.yaml"
+  PACKAGES_TO_COPY: "copy_from.yaml"
 
   # Appveyor machines come with miniconda already installed.
   CONDA_INSTALL_LOCN: "C:\\Miniconda3-x64"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,11 @@ environment:
   # Anaconda.org channel to which packages should be uploaded.
   DESTINATION_CONDA_CHANNEL: "astropy"
 
+  # File with list of packages to potentially copy from conda-forge.
+  # At the moment, copying is NOT done here because doing it on
+  # one platform copies everything.
+  PACKAGES_TO_COPY: "copy_me.yaml"
+
   # Appveyor machines come with miniconda already installed.
   CONDA_INSTALL_LOCN: "C:\\Miniconda3-x64"
 


### PR DESCRIPTION
This PR is the next step in moving builds over to conda-forge. I'm expecting the packages to be copied to include several win32 builds of reproject (and maybe others).

@bsipocz -- if this passes, let's merge it, and then, if the merge passes, I'll set up a cron job. There is an astroscrappy recipe PR open on conda-forge, so that will be the next test of the infrastructure (astroscrappy doesn't have builds for recent numpy/python I think).

Nothing should really change in the short run; I'll put together a plan for migrating recipes.