### PR TITLE
Drop hgtools from channel

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -106,9 +106,6 @@
 
 - name: pyephem
 
-- name: hgtools
-  version: '6.3'
-
 # lmfit is required for omnifit
 - name: lmfit
 


### PR DESCRIPTION
hgtools was a requirement of keyring but is no longer. It was replaced by setuptools_scm which is available in defaults