### PR TITLE
Adding astropy to be copied over from conda-forge

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -6,6 +6,9 @@
 - name: astropy-helpers
   version: 2.0
 
+# We also have astropy in this channel
+- name: astropy
+
 - name: glueviz
   # list only the name of packages that have conda-forge build, no version
   # or other info required


### PR DESCRIPTION
As this was discussed on slack with @astrofrog and @eteq.
Now that we will have a separate stable and LTS branches, anaconda will probably drop distributing the LTS versions, while for our users and affiliated CI testing it would be valuable to get it from a channel they anyway use (rather than start using conda-forge).