### PR TITLE
Add missing affiliated packages that are already on conda-forge

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -97,6 +97,12 @@
 
 - name: hips
 
+- name: dust_extinction
+
+- name: hendrics
+
+- name: stingray
+
 ################################################################
 # Infrastructure packages                                      #
 ################################################################


### PR DESCRIPTION
This addresses part of #175 