### PR TITLE
Update gala package name

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -91,7 +91,7 @@
 
 - name: cluster-lensing
 
-- name: astro-gala
+- name: gala
 
 - name: galpy
 


### PR DESCRIPTION
I recently updated the pypi/conda-forge name of astro-gala so now it is simply "gala"