### PR TITLE
MNT: Replace master with main

### DIFF
--- a/.github/workflows/copy_conda_packages.yml
+++ b/.github/workflows/copy_conda_packages.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - master
+      - main
   schedule:
     # Run once a day at 21:20 UTC
     - cron: '20 14 * * *'

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ conda config --add channels astropy
 
 # For maintainers/contributors
 
-[![Build Status](https://travis-ci.org/astropy/conda-channel-astropy.svg?branch=master)](https://travis-ci.org/astropy/conda-channel-astropy)
+[![Build Status](https://travis-ci.org/astropy/conda-channel-astropy.svg?branch=main)](https://travis-ci.org/astropy/conda-channel-astropy)
 
 ## Dependencies
 
@@ -20,7 +20,7 @@ This packages uses the file `sync.py` from https://github.com/glue-viz/conda-syn
 
 ## Updating an existing package to a new version
 
-Update the package on conda-forge. Once a day a cron job is run to copy packages over to this channel. If an immediate copy is needed, push an empty commit to master.
+Update the package on conda-forge. Once a day a cron job is run to copy packages over to this channel. If an immediate copy is needed, push an empty commit to main.
 
 ## Adding a new package
 


### PR DESCRIPTION
This PR attempts to replace all mention of `master` to `main` in this repository. This should be reviewed and merged right after the maintainer has renamed the default branch.

This is an automated update made by the `batchpr` tool :robot: - feel free to close if it doesn't look good! You can report issues to @pllim.

This is part of #188 